### PR TITLE
feat: prevent caret from shifting to the end when typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The [default styles](https://github.com/canutin/svelte-currency-input/blob/main/
 Here's ways in which you can contribute:
 
 - Found a bug? Open a [new issue](https://github.com/canutin/svelte-currency-input/issues/new)
-- Browse our [existing issues](https://github.com/canutin/svelte-currency-input/issues)
+- Comment or upvote [existing issues](https://github.com/canutin/svelte-currency-input/issues)
 - Submit a [pull request](https://github.com/canutin/svelte-currency-input/pulls)
 
 ## Developing

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -39,6 +39,7 @@
 		if (!isDeletion && !isModifier && !isArrowKey && isInvalidCharacter) event.preventDefault();
 	};
 
+	let inputTarget: HTMLInputElement;
 	const currencyDecimal = new Intl.NumberFormat(locale).format(1.1).charAt(1); // '.' or ','
 	const isDecimalComma = currencyDecimal === ','; // Remove currency formatting from `formattedValue` so we can assign it to `value`
 	const currencySymbol = formatCurrency(0, 0)
@@ -54,6 +55,9 @@
 		const ignoreSymbols = [currencySymbol, `-${currencySymbol}`, '-'];
 		const strippedUnformattedValue = formattedValue.replace(' ', '');
 		if (ignoreSymbols.includes(strippedUnformattedValue)) return;
+
+		// Set the starting caret positions
+		inputTarget = event.target as HTMLInputElement;
 
 		// Remove all characters that arent: numbers, commas, periods (or minus signs if `isNegativeAllowed`)
 		let unformattedValue = isNegativeAllowed
@@ -75,7 +79,22 @@
 	};
 
 	const setFormattedValue = () => {
+		// Previous caret position
+		const startCaretPosition = inputTarget?.selectionStart || 0;
+		const previousFormattedValueLength = formattedValue.length;
+
+		// Apply formatting to input
 		formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, 0);
+
+		// New caret position
+		const endCaretPosition =
+			startCaretPosition + formattedValue.length - previousFormattedValueLength;
+
+		// HACK:
+		// Delay setting the new caret position until the input has been formatted
+		setTimeout(() => {
+			inputTarget?.setSelectionRange(endCaretPosition, endCaretPosition);
+		}, 0.1);
 	};
 
 	let formattedValue = '';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,7 +33,7 @@
 
 		<CurrencyInput name="yen" value={5678.9} locale="ja-JA" currency="JPY" />
 		<CurrencyInput name="shekel" value={97532.95} disabled={true} locale="il-IL" currency="ILS" />
-		<CurrencyInput name="euro" value={-42069.69} locale="nl-NL" currency="EUR" />
+		<CurrencyInput name="euro" value={-42069.69} locale="de-DE" currency="EUR" />
 		<CurrencyInput
 			name="won"
 			placeholder={1234.56}

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -85,7 +85,7 @@ test.describe('CurrencyInput', () => {
 					yen: '5678.9',
 					'formatted-yen': '￥5,678.9',
 					euro: '-42069.69',
-					'formatted-euro': '€ -42.069,69',
+					'formatted-euro': '-42.069,69 €',
 					won: '0',
 					'formatted-won': ''
 				},


### PR DESCRIPTION
It's fairly usable but there are some edge cases with funky behavior.

Most prominently in currencies that have a trailing symbol, typing a number from scratch in an empty input causes the caret to always be shifted towards the end, after the currency symbol: `99,95| €` > `99,95 €|`

Fixes #2