### PR TITLE
fix: formatting triggered for zeros added after fractionDigits limit

### DIFF
--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -63,10 +63,7 @@
 			// Don't format if `formattedValue` is ['$', '-$', "-"]
 			const ignoreSymbols = [currencySymbol, `-${currencySymbol}`, '-'];
 			const strippedUnformattedValue = formattedValue.replace(' ', '');
-			if (ignoreSymbols.includes(strippedUnformattedValue)) {
-				value = 0;
-				return;
-			};
+			if (ignoreSymbols.includes(strippedUnformattedValue)) return;
 
 			// Set the starting caret positions
 			inputTarget = event.target as HTMLInputElement;

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -85,12 +85,14 @@
 			// The order of the following operations is *critical*
 			unformattedValue = unformattedValue.replace(isDecimalComma ? /\./g : /\,/g, ''); // Remove all group symbols
 			if (isDecimalComma) unformattedValue = unformattedValue.replace(',', '.'); // If the decimal point is a comma, replace it with a period
+
 			// If the zero-key has been pressed
 			// and if the current `value` is the same as the `value` before the key-press
 			// formatting may need to be done (Issue #30)
-			let prevValue = value;
+			const previousValue = value;
 			value = parseFloat(unformattedValue);
-			if (event && prevValue == value) {
+
+			if (event && previousValue === value) {
 				// Do the formatting if the number of digits after the decimal point exceeds `fractionDigits`
 				if (unformattedValue.includes('.') && unformattedValue.split('.')[1].length > fractionDigits)
 				{

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -25,7 +25,7 @@
 			currency: currency,
 			style: 'currency',
 			maximumFractionDigits: maximumFractionDigits || 0,
-			minimumFractionDigits: minimumFractionDigits || 0,
+			minimumFractionDigits: minimumFractionDigits || 0
 		}).format(value);
 	};
 
@@ -70,9 +70,8 @@
 
 			// Reverse the value when minus is pressed
 			if (isNegativeAllowed && event.key === '-') value = value * -1;
-
 		}
-		
+
 		// Remove all characters that arent: numbers, commas, periods (or minus signs if `isNegativeAllowed`)
 		let unformattedValue = isNegativeAllowed
 			? formattedValue.replace(/[^0-9,.-]/g, '')


### PR DESCRIPTION
Fixes #30, #33

Current Behaviour 
Adding 0s (after the decimal point) after the `fractionDigits` limit does not trigger formatting (See #30). This is due to the fact that the `setFormattedValue` function is called only when the numerical value of `value` changes.

Fix
In order to fix the above bug, a condition which checks for this specific case has been included in the code and handled appropriately: formatting is now triggered when the `fractionDigits` limit is exceeded. In the process of fixing this, another bug was uncovered (#36) and this PR includes that fix as well.